### PR TITLE
Fix node auth

### DIFF
--- a/assets/apiserver.conf
+++ b/assets/apiserver.conf
@@ -25,6 +25,7 @@ DNS.15 = *.ap-south-1.elb.amazonaws.com
 DNS.16 = *.sa-east-1.elb.amazonaws.com
 DNS.17 = $ENV::SERVICE_DNS_NAME
 DNS.18 = $ENV::CUSTOM_API_DNS
+DNS.19 = $ENV::HOSTNAME
 IP.1 = $ENV::SERVICE_IP
 IP.2 = $ENV::KUBE_SERVICE_IP
 IP.3 = $ENV::HOST_IP

--- a/assets/generate_apiserver.sh
+++ b/assets/generate_apiserver.sh
@@ -7,19 +7,21 @@ mkdir -p /output/etcd/ssl
 
 # Variables are:
 # SERVICE_DNS_NAME - defaults to localhost
+# SERVICE_SHORT_NAME - defaults to localhost
 # CUSTOM_API_DNS - defaults to localhost
 # SERVICE_IP - defaults to 127.0.0.1
 # HOST_IP - defaults to 127.0.0.1
 
 if [ -z "$SERVICE_DNS_NAME" ]; then
-  export SERVICE_DNS_NAME=localhost 
+  export SERVICE_DNS_NAME=localhost
   echo "Did not find Service DNS Name - defaulting to ${SERVICE_DNS_NAME}";
 else
   echo "Found Service DNS Name - ${SERVICE_DNS_NAME}";
 fi
+SERVICE_SHORT_NAME=${SERVICE_DNS_NAME%%.*}
 
 if [ -z "$CUSTOM_API_DNS" ]; then
-  export CUSTOM_API_DNS=localhost 
+  export CUSTOM_API_DNS=localhost
   echo "Did not find a custom ELB DNS Name for the API Server - defaulting to ${CUSTOM_API_DNS}";
 else
   echo "Found custom ELB DNS Name for the API Server - ${CUSTOM_API_DNS}";
@@ -48,7 +50,7 @@ fi
 
 cp /input/ca.pem /output/kubernetes/ssl/ca.pem
 openssl genrsa -out /output/kubernetes/ssl/apiserver-key.pem 2048
-openssl req -new -key /output/kubernetes/ssl/apiserver-key.pem -out /output/kubernetes/ssl/apiserver.csr -subj "/CN=kube-apiserver" -config /assets/apiserver.conf
+openssl req -new -key /output/kubernetes/ssl/apiserver-key.pem -out /output/kubernetes/ssl/apiserver.csr -subj "/O=system:nodes,/CN=system:node:${SERVICE_SHORT_NAME}" -config /assets/apiserver.conf
 openssl x509 -req -in /output/kubernetes/ssl/apiserver.csr -CA /output/kubernetes/ssl/ca.pem -CAkey /input/ca-key.pem -CAcreateserial -out /output/kubernetes/ssl/apiserver.pem -days 3650 -extensions v3_req -extfile /assets/apiserver.conf
 
 cp /input/ca.pem /output/etcd/ssl/client-ca.pem

--- a/assets/generate_apiserver.sh
+++ b/assets/generate_apiserver.sh
@@ -7,7 +7,7 @@ mkdir -p /output/etcd/ssl
 
 # Variables are:
 # SERVICE_DNS_NAME - defaults to localhost
-# SERVICE_SHORT_NAME - defaults to localhost
+# SHORT_HOST_NAME - defaults to localhost
 # CUSTOM_API_DNS - defaults to localhost
 # SERVICE_IP - defaults to 127.0.0.1
 # HOST_IP - defaults to 127.0.0.1
@@ -18,7 +18,14 @@ if [ -z "$SERVICE_DNS_NAME" ]; then
 else
   echo "Found Service DNS Name - ${SERVICE_DNS_NAME}";
 fi
-SERVICE_SHORT_NAME=${SERVICE_DNS_NAME%%.*}
+
+if [ -z "$HOSTNAME" ]; then
+  export HOSTNAME=localhost
+  echo "Did not find host name - defaulting to ${HOSTNAME}";
+else
+  echo "Found host name - ${HOSTNAME}";
+fi
+SHORT_HOST_NAME=${SERVICE_DNS_NAME%%.*}
 
 if [ -z "$CUSTOM_API_DNS" ]; then
   export CUSTOM_API_DNS=localhost
@@ -50,7 +57,7 @@ fi
 
 cp /input/ca.pem /output/kubernetes/ssl/ca.pem
 openssl genrsa -out /output/kubernetes/ssl/apiserver-key.pem 2048
-openssl req -new -key /output/kubernetes/ssl/apiserver-key.pem -out /output/kubernetes/ssl/apiserver.csr -subj "/O=system:nodes,/CN=system:node:${SERVICE_SHORT_NAME}" -config /assets/apiserver.conf
+openssl req -new -key /output/kubernetes/ssl/apiserver-key.pem -out /output/kubernetes/ssl/apiserver.csr -subj "/O=system:nodes,/CN=system:node:${SHORT_HOST_NAME}" -config /assets/apiserver.conf
 openssl x509 -req -in /output/kubernetes/ssl/apiserver.csr -CA /output/kubernetes/ssl/ca.pem -CAkey /input/ca-key.pem -CAcreateserial -out /output/kubernetes/ssl/apiserver.pem -days 3650 -extensions v3_req -extfile /assets/apiserver.conf
 
 cp /input/ca.pem /output/etcd/ssl/client-ca.pem

--- a/assets/generate_worker.sh
+++ b/assets/generate_worker.sh
@@ -6,8 +6,18 @@ mkdir -p /output/kubernetes/ssl
 mkdir -p /output/etcd/ssl
 
 # Variables are:
+# SERVICE_DNS_NAME - defaults to localhost
+# SERVICE_SHORT_NAME - defaults to localhost
 # WORKER_IP - defaults to 127.0.0.1
 # HOST_IP - defaults to 127.0.0.1
+
+if [ -z "$SERVICE_DNS_NAME" ]; then
+  export SERVICE_DNS_NAME=localhost
+  echo "Did not find Service DNS Name - defaulting to ${SERVICE_DNS_NAME}";
+else
+  echo "Found Service DNS Name - ${SERVICE_DNS_NAME}";
+fi
+SERVICE_SHORT_NAME=${SERVICE_DNS_NAME%%.*}
 
 if [ -z "$WORKER_IP" ]; then
   export WORKER_IP=127.0.0.1
@@ -25,13 +35,10 @@ fi
 
 cp /input/ca.pem /output/kubernetes/ssl/ca.pem
 openssl genrsa -out /output/kubernetes/ssl/worker-key.pem 2048
-openssl req -new -key /output/kubernetes/ssl/worker-key.pem -out /output/kubernetes/ssl/worker.csr -subj "/CN=kube-worker" -config /assets/worker.conf
+openssl req -new -key /output/kubernetes/ssl/worker-key.pem -out /output/kubernetes/ssl/worker.csr -subj "/O=system:nodes,/CN=system:node:${SERVICE_SHORT_NAME}" -config /assets/worker.conf
 openssl x509 -req -in /output/kubernetes/ssl/worker.csr -CA /output/kubernetes/ssl/ca.pem -CAkey /input/ca-key.pem -CAcreateserial -out /output/kubernetes/ssl/worker.pem -days 3650 -extensions v3_req -extfile /assets/worker.conf
 
 cp /input/ca.pem /output/etcd/ssl/client-ca.pem
 openssl genrsa -out /output/etcd/ssl/client-key.pem 2048
 openssl req -new -key /output/etcd/ssl/client-key.pem -out /output/etcd/ssl/client.csr -subj "/CN=etcd-client" -config /assets/etcd_client.conf
 openssl x509 -req -in /output/etcd/ssl/client.csr -CA /output/etcd/ssl/client-ca.pem -CAkey /input/ca-key.pem -CAcreateserial -out /output/etcd/ssl/client.pem -days 3650 -extensions v3_req -extfile /assets/etcd_client.conf
-
-
-

--- a/assets/generate_worker.sh
+++ b/assets/generate_worker.sh
@@ -6,18 +6,18 @@ mkdir -p /output/kubernetes/ssl
 mkdir -p /output/etcd/ssl
 
 # Variables are:
-# SERVICE_DNS_NAME - defaults to localhost
-# SERVICE_SHORT_NAME - defaults to localhost
+# HOSTNAME - defaults to localhost
+# SHORT_HOST_NAME - defaults to localhost
 # WORKER_IP - defaults to 127.0.0.1
 # HOST_IP - defaults to 127.0.0.1
 
-if [ -z "$SERVICE_DNS_NAME" ]; then
-  export SERVICE_DNS_NAME=localhost
-  echo "Did not find Service DNS Name - defaulting to ${SERVICE_DNS_NAME}";
+if [ -z "$HOSTNAME" ]; then
+  export HOSTNAME=localhost
+  echo "Did not find host name - defaulting to ${HOSTNAME}";
 else
-  echo "Found Service DNS Name - ${SERVICE_DNS_NAME}";
+  echo "Found host name - ${HOSTNAME}";
 fi
-SERVICE_SHORT_NAME=${SERVICE_DNS_NAME%%.*}
+SHORT_HOST_NAME=${HOSTNAME%%.*}
 
 if [ -z "$WORKER_IP" ]; then
   export WORKER_IP=127.0.0.1
@@ -35,7 +35,7 @@ fi
 
 cp /input/ca.pem /output/kubernetes/ssl/ca.pem
 openssl genrsa -out /output/kubernetes/ssl/worker-key.pem 2048
-openssl req -new -key /output/kubernetes/ssl/worker-key.pem -out /output/kubernetes/ssl/worker.csr -subj "/O=system:nodes,/CN=system:node:${SERVICE_SHORT_NAME}" -config /assets/worker.conf
+openssl req -new -key /output/kubernetes/ssl/worker-key.pem -out /output/kubernetes/ssl/worker.csr -subj "/O=system:nodes,/CN=system:node:${SHORT_HOST_NAME}" -config /assets/worker.conf
 openssl x509 -req -in /output/kubernetes/ssl/worker.csr -CA /output/kubernetes/ssl/ca.pem -CAkey /input/ca-key.pem -CAcreateserial -out /output/kubernetes/ssl/worker.pem -days 3650 -extensions v3_req -extfile /assets/worker.conf
 
 cp /input/ca.pem /output/etcd/ssl/client-ca.pem

--- a/assets/worker.conf
+++ b/assets/worker.conf
@@ -7,7 +7,7 @@ basicConstraints = CA:FALSE
 keyUsage = nonRepudiation, digitalSignature, keyEncipherment
 subjectAltName = @alt_names
 [alt_names]
-DNS.1 = $ENV::SERVICE_DNS_NAME
+DNS.1 = $ENV::HOSTNAME
 IP.1 = $ENV::WORKER_IP
 IP.2 = $ENV::HOST_IP
 IP.3 = 127.0.0.1

--- a/assets/worker.conf
+++ b/assets/worker.conf
@@ -7,6 +7,7 @@ basicConstraints = CA:FALSE
 keyUsage = nonRepudiation, digitalSignature, keyEncipherment
 subjectAltName = @alt_names
 [alt_names]
+DNS.1 = $ENV::SERVICE_DNS_NAME
 IP.1 = $ENV::WORKER_IP
 IP.2 = $ENV::HOST_IP
 IP.3 = 127.0.0.1


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
-->

**What this PR does / why we need it**:
apiserver's Node authorization mode requires specific organization and
common names be set in the certificate in order to authorize a "node".
This adds `O=system:nodes` to allow the application wielding this
certificate to be a kubernetes node. It also adds the
`CN=system.node.<hostname>` which is a documented requirement.
