### PR TITLE
Conditional check it client-ca.pem already exists, in which case to n…

### DIFF
--- a/assets/generate_etcd.sh
+++ b/assets/generate_etcd.sh
@@ -3,7 +3,6 @@
 # Assumes /input/ has ca.pem and ca-key.pem
 
 ETCD_CONFIG=$1
-ETCD_INDEX=$2
 
 mkdir -p /output/etcd/server-$ETCD_CONFIG/ssl
 mkdir -p /output/etcd/ssl
@@ -54,7 +53,7 @@ openssl genrsa -out /output/etcd/server-$ETCD_CONFIG/ssl/server-key.pem 2048
 openssl req -new -key /output/etcd/server-$ETCD_CONFIG/ssl/server-key.pem -out /output/etcd/server-$ETCD_CONFIG/ssl/server.csr -subj "/CN=etcd-server" -config /assets/etcd_server.conf
 openssl x509 -req -in /output/etcd/server-$ETCD_CONFIG/ssl/server.csr -CA /output/etcd/server-$ETCD_CONFIG/ssl/server-ca.pem -CAkey /input/ca-key.pem -CAcreateserial -out /output/etcd/server-$ETCD_CONFIG/ssl/server.pem -days 3650 -extensions v3_req -extfile /assets/etcd_server.conf
 
-if [ $ETCD_INDEX == 0 ]
+if [ -f /output/etcd/ssl/client-ca.pem ]
 then
   # these files are shared etcd and etcdEvents client certs, they are shared 
   # because Kubernetes API server has a flag for a single etcd cert location


### PR DESCRIPTION
…ot try to make dup cert

<!--  Thanks for sending a pull request!  Here are some tips for you:
-->

**What this PR does / why we need it**:
We need multiple certs for all instances of etcd running on node, but not multiple client certs, this will not remake them if they already exist. 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
